### PR TITLE
Data table linking-related updates

### DIFF
--- a/src/main/kotlin/com/openlattice/mechanic/pods/MechanicUpgradePod.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/pods/MechanicUpgradePod.kt
@@ -263,4 +263,9 @@ class MechanicUpgradePod {
     fun setOriginIdToNonNullUpgrade(): SetOriginIdToNonNullUpgrade {
         return SetOriginIdToNonNullUpgrade(toolbox())
     }
+
+    @Bean
+    fun addOriginIdToDataPrimaryKey(): AddOriginIdToDataPrimaryKey {
+        return AddOriginIdToDataPrimaryKey(toolbox())
+    }
 }

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/AddOriginIdToDataPrimaryKey.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/AddOriginIdToDataPrimaryKey.kt
@@ -1,0 +1,39 @@
+package com.openlattice.mechanic.upgrades
+
+import com.openlattice.mechanic.Toolbox
+import com.openlattice.postgres.PostgresColumn.ORIGIN_ID
+import com.openlattice.postgres.PostgresDataTables
+import com.openlattice.postgres.PostgresTable.DATA
+import org.slf4j.LoggerFactory
+
+class AddOriginIdToDataPrimaryKey(private val toolbox: Toolbox) : Upgrade {
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(AddOriginIdToDataPrimaryKey::class.java)
+    }
+
+    override fun getSupportedVersion(): Long {
+        return Version.V2019_10_03.value
+    }
+
+    override fun upgrade(): Boolean {
+
+        val pkey = (PostgresDataTables.buildDataTableDefinition().primaryKey + ORIGIN_ID).joinToString(",") { it.name }
+
+        val dropPkey = "ALTER TABLE ${DATA.name} DROP CONSTRAINT ${DATA.name}_pkey"
+        val updatePkey = "ALTER TABLE ${DATA.name} ADD PRIMARY KEY ($pkey)"
+
+        logger.info("About to drop and recreate primary key of data.")
+
+        toolbox.hds.connection.use { conn ->
+            conn.autoCommit = false
+            conn.createStatement().executeUpdate( dropPkey )
+            conn.createStatement().executeUpdate( updatePkey )
+            conn.commit()
+        }
+
+        logger.info("Finished updating primary key.")
+
+        return true
+    }
+}

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/AddOriginIdToDataPrimaryKey.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/AddOriginIdToDataPrimaryKey.kt
@@ -20,8 +20,18 @@ class AddOriginIdToDataPrimaryKey(private val toolbox: Toolbox) : Upgrade {
 
         val pkey = (PostgresDataTables.buildDataTableDefinition().primaryKey + ORIGIN_ID).joinToString(",") { it.name }
 
-        val dropPkey = "ALTER TABLE ${DATA.name} DROP CONSTRAINT ${DATA.name}_pkey"
-        val updatePkey = "ALTER TABLE ${DATA.name} ADD PRIMARY KEY ($pkey)"
+        logger.info("Adding new index to data to be used for primary key.")
+
+        val createNewPkeyIndex = "CREATE UNIQUE INDEX CONCURRENTLY ${DATA.name}_pkey_idx ON ${DATA.name} ($pkey)"
+
+        toolbox.hds.connection.use { conn ->
+            conn.createStatement().execute( createNewPkeyIndex )
+        }
+
+        logger.info("Finished creating index. About to drop pkey constraint and create new constraint using new index.")
+
+        val dropPkey = "ALTER TABLE ${DATA.name} DROP CONSTRAINT ${DATA.name}_pkey1"
+        val updatePkey = "ALTER TABLE ${DATA.name} ADD CONSTRAINT ${DATA.name}_pkey PRIMARY KEY USING INDEX ${DATA.name}_pkey_idx"
 
         logger.info("About to drop and recreate primary key of data.")
 

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/SetOriginIdToNonNullUpgrade.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/SetOriginIdToNonNullUpgrade.kt
@@ -1,40 +1,40 @@
 package com.openlattice.mechanic.upgrades
 
-import com.google.common.base.Stopwatch
 import com.openlattice.IdConstants
 import com.openlattice.mechanic.Toolbox
 import com.openlattice.postgres.PostgresColumn.ORIGIN_ID
 import com.openlattice.postgres.PostgresDataTables
 import com.openlattice.postgres.PostgresTable.DATA
 import org.slf4j.LoggerFactory
-import java.util.concurrent.TimeUnit
 
 class SetOriginIdToNonNullUpgrade(private val toolbox: Toolbox) : Upgrade {
 
     companion object {
-        private val logger = LoggerFactory.getLogger(Toolbox::class.java)
+        private val logger = LoggerFactory.getLogger(SetOriginIdToNonNullUpgrade::class.java)
     }
 
     override fun getSupportedVersion(): Long {
-        return Version.V2019_09_15.value
+        return Version.V2019_10_03.value
     }
 
     override fun upgrade(): Boolean {
 
-        val updateQuery = "UPDATE ${DATA.name} SET ${ORIGIN_ID.name} = ${IdConstants.EMPTY_ORIGIN_ID.id}::uuid WHERE ${ORIGIN_ID.name} = NULL"
-        toolbox.rateLimitedQuery( 16, updateQuery, logger)
+        val renameOriginIdCol = "ALTER TABLE ${DATA.name} RENAME COLUMN ${ORIGIN_ID.name} TO origin_id_old"
+        val addOriginIdCol = "ALTER TABLE ${DATA.name} ADD COLUMN ${ORIGIN_ID.sql()}"
 
-        val pkey = PostgresDataTables.buildDataTableDefinition().primaryKey.joinToString(",") { it.name }
-        val dropPkey = "ALTER TABLE ${DATA.name} DROP CONSTRAINT ${DATA.name}_pkey"
-        val updatePkey = "ALTER TABLE ${DATA.name} ADD PRIMARY KEY ($pkey)"
-        val updateDefaultValue = "ALTER TABLE ${DATA.name} ALTER COLUMN ${ORIGIN_ID.name} SET DEFAULT '${IdConstants.EMPTY_ORIGIN_ID.id}'"
+
+        logger.info("About to rename origin_id and add new origin_id column with default value.")
+
         toolbox.hds.connection.use { conn ->
             conn.autoCommit = false
-            conn.createStatement().executeUpdate( dropPkey )
-            conn.createStatement().executeUpdate( updatePkey )
-            conn.createStatement().executeUpdate( updateDefaultValue )
+            conn.createStatement().executeUpdate( renameOriginIdCol )
+            conn.createStatement().executeUpdate( addOriginIdCol )
             conn.commit()
-            return true
         }
+
+        logger.info("Finished adding new origin_id column.")
+
+        return true
+
     }
 }


### PR DESCRIPTION
- update SetOriginIdToNonNullUpgrade to add a new origin_id column with default value (faster)
- split out data primary key change to separate upgrade