### PR TITLE
cleanup

### DIFF
--- a/src/main/kotlin/com/openlattice/mechanic/Mechanic.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/Mechanic.kt
@@ -47,8 +47,6 @@ import com.openlattice.mechanic.MechanicCli.Companion.REINDEX
 import com.openlattice.mechanic.MechanicCli.Companion.SQL
 import com.openlattice.mechanic.MechanicCli.Companion.UPGRADE
 import com.openlattice.mechanic.checks.Check
-import com.openlattice.mechanic.integrity.EdmChecks
-import com.openlattice.mechanic.integrity.IntegrityChecks
 import com.openlattice.mechanic.pods.MechanicUpgradePod
 import com.openlattice.mechanic.reindex.Reindexer
 import com.openlattice.mechanic.upgrades.Upgrade

--- a/src/main/kotlin/com/openlattice/mechanic/Mechanic.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/Mechanic.kt
@@ -22,9 +22,7 @@
 package com.openlattice.mechanic
 
 import com.google.common.base.Preconditions.checkArgument
-import com.google.common.base.Stopwatch
 import com.google.common.collect.Maps
-import com.kryptnostic.rhizome.configuration.ConfigurationConstants
 import com.kryptnostic.rhizome.configuration.ConfigurationConstants.Profiles.AWS_CONFIGURATION_PROFILE
 import com.kryptnostic.rhizome.configuration.ConfigurationConstants.Profiles.LOCAL_CONFIGURATION_PROFILE
 import com.kryptnostic.rhizome.core.Rhizome
@@ -44,7 +42,6 @@ import com.openlattice.mechanic.MechanicCli.Companion.HELP
 import com.openlattice.mechanic.MechanicCli.Companion.LOCAL
 import com.openlattice.mechanic.MechanicCli.Companion.POSTGRES
 import com.openlattice.mechanic.MechanicCli.Companion.REINDEX
-import com.openlattice.mechanic.MechanicCli.Companion.SQL
 import com.openlattice.mechanic.MechanicCli.Companion.UPGRADE
 import com.openlattice.mechanic.checks.Check
 import com.openlattice.mechanic.pods.MechanicUpgradePod
@@ -54,6 +51,7 @@ import com.openlattice.postgres.PostgresPod
 import org.apache.commons.lang3.StringUtils
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import kotlin.system.exitProcess
 
 
 private val logger = LoggerFactory.getLogger(Mechanic::class.java)
@@ -78,19 +76,19 @@ fun main(args: Array<String>) {
             "Local or AWS configuration profile must be specified"
     )
 
-    val args = mutableListOf<String>()
+    val ars = mutableListOf<String>()
 
     if (cl.hasOption(AWS)) {
-        args.add(AWS_CONFIGURATION_PROFILE)
+        ars.add(AWS_CONFIGURATION_PROFILE)
     } else if (cl.hasOption(LOCAL_CONFIGURATION_PROFILE)) {
-        args.add(LOCAL_CONFIGURATION_PROFILE)
+        ars.add(LOCAL_CONFIGURATION_PROFILE)
     }
 
     if (cl.hasOption(POSTGRES)) {
-        args.add(PostgresPod.PROFILE)
+        ars.add(PostgresPod.PROFILE)
     }
 
-    mechanic.sprout(*args.toTypedArray())
+    mechanic.sprout(*ars.toTypedArray())
 
     if (cl.hasOption(CHECK)) {
         val checks = cl.getOptionValues(CHECK).toSet()
@@ -106,14 +104,14 @@ fun main(args: Array<String>) {
         mechanic.reIndex()
     }
 
-    if (cl.hasOption(SQL)) {
+//    if (cl.hasOption(SQL)) {
+//
+//    }
 
-    }
-
-    val w = Stopwatch.createStarted()
+//    val w = Stopwatch.createStarted()
 
     mechanic.close()
-    System.exit(0)
+    exitProcess(0)
 
 }
 
@@ -139,11 +137,11 @@ class Mechanic {
         var awsProfile = false
         var localProfile = false
         for (profile in activeProfiles) {
-            if (StringUtils.equals(ConfigurationConstants.Profiles.AWS_CONFIGURATION_PROFILE, profile)) {
+            if (StringUtils.equals(AWS_CONFIGURATION_PROFILE, profile)) {
                 awsProfile = true
             }
 
-            if (StringUtils.equals(ConfigurationConstants.Profiles.LOCAL_CONFIGURATION_PROFILE, profile)) {
+            if (StringUtils.equals(LOCAL_CONFIGURATION_PROFILE, profile)) {
                 localProfile = true
             }
 
@@ -151,7 +149,7 @@ class Mechanic {
         }
 
         if (!awsProfile && !localProfile) {
-            context.environment.addActiveProfile(ConfigurationConstants.Profiles.LOCAL_CONFIGURATION_PROFILE)
+            context.environment.addActiveProfile(LOCAL_CONFIGURATION_PROFILE)
         }
 
         /*if ( additionalPods.size() > 0 ) {

--- a/src/main/kotlin/com/openlattice/mechanic/Toolbox.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/Toolbox.kt
@@ -106,7 +106,7 @@ class Toolbox(
         } finally {
             limiter.release()
         }
-        return true;
+        return true
     }
 
 }

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/CreateDataTableIndexes.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/CreateDataTableIndexes.kt
@@ -2,7 +2,6 @@ package com.openlattice.mechanic.upgrades
 
 
 import com.openlattice.mechanic.Toolbox
-import com.openlattice.postgres.CitusDistributedTableDefinition
 import com.openlattice.postgres.PostgresDataTables
 import org.slf4j.LoggerFactory
 

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/DataExpirationUpgrade.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/DataExpirationUpgrade.kt
@@ -4,7 +4,6 @@ package com.openlattice.mechanic.upgrades
 import com.openlattice.mechanic.Toolbox
 import com.openlattice.postgres.PostgresColumn
 import com.openlattice.postgres.PostgresTable
-import java.sql.Types
 
 class DataExpirationUpgrade(private val toolbox: Toolbox) : Upgrade {
     override fun upgrade(): Boolean {
@@ -12,7 +11,7 @@ class DataExpirationUpgrade(private val toolbox: Toolbox) : Upgrade {
             val stmt = it.prepareStatement(addExpirationColumnsQuery())
             stmt.execute()
         }
-        return true;
+        return true
     }
 
     override fun getSupportedVersion(): Long {

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/GraphProcessing.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/GraphProcessing.kt
@@ -24,9 +24,11 @@ package com.openlattice.mechanic.upgrades
 import com.google.common.base.Stopwatch
 import com.openlattice.edm.type.PropertyType
 import com.openlattice.mechanic.Toolbox
-import com.openlattice.postgres.*
 import com.openlattice.postgres.DataTables.*
 import com.openlattice.postgres.PostgresColumn.*
+import com.openlattice.postgres.PostgresDatatype
+import com.openlattice.postgres.PostgresIndexDefinition
+import com.openlattice.postgres.PostgresTableDefinition
 import org.slf4j.LoggerFactory
 import java.util.*
 import java.util.concurrent.Callable
@@ -132,18 +134,18 @@ class GraphProcessing(private val toolbox: Toolbox) : Upgrade {
 }
 
 private fun alterPropertyTypeTableWithDefaults(propertyTypeId: UUID): String {
-    val propertyTableName = quote(DataTables.propertyTableName(propertyTypeId))
+    val propertyTableName = quote(propertyTableName(propertyTypeId))
     return "ALTER TABLE $propertyTableName ALTER COLUMN ${LAST_PROPAGATE.name} SET DEFAULT now();" +
             "ALTER TABLE $propertyTableName ALTER COLUMN ${LAST_PROPAGATE.name} SET NOT NULL;"
 }
 
 private fun updatePropertyTypeTableSql(propertyTypeId: UUID): String {
-    val propertyTableName = quote(DataTables.propertyTableName(propertyTypeId))
+    val propertyTableName = quote(propertyTableName(propertyTypeId))
     return "UPDATE $propertyTableName SET ${LAST_PROPAGATE.name} = now() WHERE LAST_PROPAGATE IS NULL"
 }
 
 private fun alterPropertyTypeTableSql(propertyTypeId: UUID): String {
-    val propertyTableName = quote(DataTables.propertyTableName(propertyTypeId))
+    val propertyTableName = quote(propertyTableName(propertyTypeId))
     return "ALTER TABLE $propertyTableName DROP COLUMN IF EXISTS ${LAST_PROPAGATE.name}; " +
             "ALTER TABLE $propertyTableName ADD COLUMN IF NOT EXISTS ${LAST_PROPAGATE.name} ${PostgresDatatype.TIMESTAMPTZ.sql()}; "
 }

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/MaterializationForeignServer.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/MaterializationForeignServer.kt
@@ -24,7 +24,6 @@ import com.openlattice.assembler.AssemblerConfiguration
 import com.openlattice.assembler.AssemblerConnectionManager
 import com.openlattice.assembler.PostgresDatabases
 import com.openlattice.postgres.mapstores.OrganizationAssemblyMapstore
-import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import org.slf4j.LoggerFactory
 import java.util.*

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/MediaServerCleanup.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/MediaServerCleanup.kt
@@ -28,8 +28,8 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.kryptnostic.rhizome.configuration.amazon.AmazonLaunchConfiguration
 import com.kryptnostic.rhizome.configuration.amazon.AwsLaunchConfiguration
 import com.openlattice.ResourceConfigurationLoader
-import com.openlattice.data.storage.aws.AwsBlobDataService
 import com.openlattice.data.storage.ByteBlobDataManager
+import com.openlattice.data.storage.aws.AwsBlobDataService
 import com.openlattice.datastore.configuration.DatastoreConfiguration
 import com.openlattice.mechanic.Toolbox
 import com.openlattice.postgres.DataTables
@@ -128,7 +128,7 @@ class MediaServerCleanup(private val toolbox: Toolbox) : Upgrade {
 
     private fun newS3Client(awsConfig: AmazonLaunchConfiguration): AmazonS3 {
         val builder = AmazonS3ClientBuilder.standard()
-        builder.region = Region.getRegion(awsConfig.region.or(Regions.DEFAULT_REGION)).name
+        builder.region = Region.getRegion(awsConfig.region.orElse(Regions.DEFAULT_REGION)).name
         return builder.build()
     }
 

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/MediaServerUpgrade.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/MediaServerUpgrade.kt
@@ -7,8 +7,8 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.kryptnostic.rhizome.configuration.amazon.AmazonLaunchConfiguration
 import com.kryptnostic.rhizome.configuration.amazon.AwsLaunchConfiguration
 import com.openlattice.ResourceConfigurationLoader
-import com.openlattice.data.storage.aws.AwsBlobDataService
 import com.openlattice.data.storage.ByteBlobDataManager
+import com.openlattice.data.storage.aws.AwsBlobDataService
 import com.openlattice.data.util.PostgresDataHasher
 import com.openlattice.datastore.configuration.DatastoreConfiguration
 import com.openlattice.mechanic.Toolbox
@@ -107,7 +107,7 @@ class MediaServerUpgrade(private val toolbox: Toolbox) : Upgrade {
 
     private fun newS3Client(awsConfig: AmazonLaunchConfiguration): AmazonS3 {
         val builder = AmazonS3ClientBuilder.standard()
-        builder.region = Region.getRegion(awsConfig.region.or(Regions.DEFAULT_REGION)).name
+        builder.region = Region.getRegion(awsConfig.region.orElse(Regions.DEFAULT_REGION)).name
         return builder.build()
     }
 

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/Organizations.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/Organizations.kt
@@ -169,7 +169,7 @@ class Organizations(
                     w.elapsed(TimeUnit.MILLISECONDS), counterIndex.get()
             )
             //Let vacuum catch up
-            Thread.sleep(60000);
+            Thread.sleep(60000)
         }
 
 //        executor.shutdown()

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/PropertyValueIndexing.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/PropertyValueIndexing.kt
@@ -1,10 +1,7 @@
 package com.openlattice.mechanic.upgrades
 
 import com.openlattice.mechanic.Toolbox
-import com.openlattice.postgres.*
 import org.slf4j.LoggerFactory
-import java.lang.Exception
-import java.util.concurrent.Callable
 
 class PropertyValueIndexing(private val toolbox: Toolbox) : Upgrade {
 

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/RegenerateIds.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/RegenerateIds.kt
@@ -78,7 +78,7 @@ class RegenerateIds(
 
 
     fun testPrincipalTrees() {
-        val keySet = principalTrees.loadAllKeys().toSet();
+        val keySet = principalTrees.loadAllKeys().toSet()
         logger.info("Key set: {}", keySet)
         val vm = principalTrees.loadAll(keySet)
         logger.info("Value map: {}", vm)
@@ -217,7 +217,7 @@ class RegenerateIds(
                     w.elapsed(TimeUnit.MILLISECONDS), counterIndex.get()
             )
             //Let vacuum catch up
-            Thread.sleep(60000);
+            Thread.sleep(60000)
         }
 
 //        executor.shutdown()
@@ -338,7 +338,7 @@ class RegenerateIds(
             semaphore.acquire()
             executor.execute {
                 hds.connection.use {
-                    var modified = false;
+                    var modified = false
                     try {
                         it.createStatement().use {
                             it.execute(
@@ -346,7 +346,7 @@ class RegenerateIds(
                                             "ADD COLUMN version bigint"
                             )
                         }
-                        modified = true;
+                        modified = true
                     } catch (e: PSQLException) {
                         logger.error("Unable to alter table $esTableName")
                     }
@@ -357,7 +357,7 @@ class RegenerateIds(
                                             "ADD COLUMN versions bigint[]"
                             )
                         }
-                        modified = true;
+                        modified = true
                     } catch (e: PSQLException) {
                         logger.error("Unable to alter table $esTableName")
 

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/RemoveDuplicates.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/RemoveDuplicates.kt
@@ -1,11 +1,7 @@
 package com.openlattice.mechanic.upgrades
 
-import com.openlattice.edm.set.EntitySetFlag
 import com.openlattice.mechanic.Toolbox
-import com.openlattice.postgres.PostgresColumn
-import com.openlattice.postgres.PostgresTable
 import org.slf4j.LoggerFactory
-import java.util.concurrent.Callable
 
 class RemoveDuplicates(private val toolbox: Toolbox) : Upgrade {
     companion object {

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/SetOriginIdToNonNullUpgrade.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/SetOriginIdToNonNullUpgrade.kt
@@ -1,9 +1,7 @@
 package com.openlattice.mechanic.upgrades
 
-import com.openlattice.IdConstants
 import com.openlattice.mechanic.Toolbox
 import com.openlattice.postgres.PostgresColumn.ORIGIN_ID
-import com.openlattice.postgres.PostgresDataTables
 import com.openlattice.postgres.PostgresTable.DATA
 import org.slf4j.LoggerFactory
 


### PR DESCRIPTION
This PR:
- Fixes a bunch of mechanical warnings
- Removing unused imports
- Removing unnecessary boxing/unboxing
- Uses singletonList for one-element lists
- Uses Java classes instead of Guava for functional constructs
- Fixes compiler warnings for upgrading from Java 5 through Java 8