### PR TITLE
add migration to push back affected datetimes from ncric data

### DIFF
--- a/src/main/kotlin/com/openlattice/mechanic/pods/MechanicUpgradePod.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/pods/MechanicUpgradePod.kt
@@ -334,4 +334,9 @@ class MechanicUpgradePod {
     fun updateAuditEntitySetPartitions(): UpdateAuditEntitySetPartitions {
         return UpdateAuditEntitySetPartitions(toolbox())
     }
+
+    @Bean
+    fun adjustNCRICDataDateTimes(): AdjustNCRICDataDateTimes {
+        return AdjustNCRICDataDateTimes(toolbox())
+    }
 }

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/AdjustNCRICDataDateTimes.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/AdjustNCRICDataDateTimes.kt
@@ -53,7 +53,7 @@ class AdjustNCRICDataDateTimes(private val toolbox: Toolbox) : Upgrade {
         return true
     }
 
-    val UPDATE_SQL = "UPDATE ${DATA.name} SET $DATETIME_COL = $DATETIME_COL + '7 hours' " + // TODO -- does daylight savings affect this?
+    val UPDATE_SQL = "UPDATE ${DATA.name} SET $DATETIME_COL = $DATETIME_COL + '8 hours' " + // TODO -- does daylight savings affect this?
             "WHERE ${ENTITY_SET_ID.name} = ? " +
             "AND ${PROPERTY_TYPE_ID.name} = ? " +
             "AND ${PARTITION.name} = ANY(?)"

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/AdjustNCRICDataDateTimes.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/AdjustNCRICDataDateTimes.kt
@@ -61,4 +61,3 @@ class AdjustNCRICDataDateTimes(private val toolbox: Toolbox) : Upgrade {
             "AND $DATETIME_COL > '2018-12-17 10:00:00.000000-00'" // we don't care about fixing data over a year old
 }
 
-}

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/AdjustNCRICDataDateTimes.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/AdjustNCRICDataDateTimes.kt
@@ -68,7 +68,7 @@ class AdjustNCRICDataDateTimes(private val toolbox: Toolbox) : Upgrade {
     }
 
     private fun getUpdateSql(rangeClause: String, offset: Int): String {
-        return "UPDATE ${DATA.name} SET $DATETIME_COL = $DATETIME_COL + '$offset hours' " +
+        return "UPDATE ${DATA.name} SET $DATETIME_COL = ($DATETIME_COL at time zone 'UTC' + interval '$offset hours') at time zone 'UTC' " +
                 "WHERE ${ENTITY_SET_ID.name} = ? " +
                 "AND ${PROPERTY_TYPE_ID.name} = ? " +
                 "AND ${PARTITION.name} = ANY(?)" +

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/AdjustNCRICDataDateTimes.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/AdjustNCRICDataDateTimes.kt
@@ -1,0 +1,61 @@
+package com.openlattice.mechanic.upgrades
+
+import com.openlattice.mechanic.Toolbox
+import com.openlattice.postgres.PostgresArrays
+import com.openlattice.postgres.PostgresColumn.*
+import com.openlattice.postgres.PostgresTable.DATA
+import org.slf4j.LoggerFactory
+
+const val DATETIME_COL = "n_timestamptz"
+
+class AdjustNCRICDataDateTimes(private val toolbox: Toolbox) : Upgrade {
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(AdjustNCRICDataDateTimes::class.java)
+    }
+
+    override fun getSupportedVersion(): Long {
+        return Version.V2019_12_12.value
+    }
+
+    override fun upgrade(): Boolean {
+
+        val entitySetsToPropertyTypes = mapOf(
+                "NCRICNotifications" to "general.datetime",
+                "NCRICResultsIn" to "general.datetime",
+                "NCRICVehicleRecords" to "ol.datelogged",
+                "NCRICRecordedBy" to "ol.datelogged",
+                "NCRICIncludes" to "date.completeddatetime"
+        )
+
+        val entitySetsByName = toolbox.entitySets.values.associate { it.name to it }
+        val propertyTypesByFqn = toolbox.propertyTypes.values.associate { it.type.fullQualifiedNameAsString to it.id }
+
+        entitySetsToPropertyTypes.entries.stream().parallel().forEach {
+            val entitySet = entitySetsByName.getValue(it.key)
+            val propertyTypeId = propertyTypesByFqn.getValue(it.value)
+
+            logger.info("About to update values for entity set ${it.key}")
+
+            toolbox.hds.connection.use { conn ->
+                conn.prepareStatement(UPDATE_SQL).use { ps ->
+                    ps.setObject(1, entitySet.id)
+                    ps.setObject(2, propertyTypeId)
+                    ps.setArray(3, PostgresArrays.createIntArray(conn, entitySet.partitions))
+
+                    ps.execute()
+                }
+            }
+
+            logger.info("Finished updating values for entity set ${it.key}")
+        }
+
+        return true
+    }
+
+    val UPDATE_SQL = "UPDATE ${DATA.name} SET $DATETIME_COL = $DATETIME_COL + '7 hours' " + // TODO -- does daylight savings affect this?
+            "WHERE ${ENTITY_SET_ID.name} = ? " +
+            "AND ${PROPERTY_TYPE_ID.name} = ? " +
+            "AND ${PARTITION.name} = ANY(?)"
+
+}

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/AdjustNCRICDataDateTimes.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/AdjustNCRICDataDateTimes.kt
@@ -34,7 +34,7 @@ class AdjustNCRICDataDateTimes(private val toolbox: Toolbox) : Upgrade {
                 " AND $DATETIME_COL >= '2018-12-17 10:00:00.000000-00' AND $DATETIME_COL < '2019-03-11 10:00:00.000000-00' " to 8 // PST (and earlier data should be expired)
         )
 
-        val entitySetsByName = toolbox.entitySets.values.associate { it.name to it }
+        val entitySetsByName = toolbox.entitySets.values.associateBy { it.name }
         val propertyTypesByFqn = toolbox.propertyTypes.values.associate { it.type.fullQualifiedNameAsString to it.id }
 
         entitySetsToPropertyTypes.entries.stream().parallel().forEach {

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/AdjustNCRICDataDateTimes.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/AdjustNCRICDataDateTimes.kt
@@ -28,12 +28,6 @@ class AdjustNCRICDataDateTimes(private val toolbox: Toolbox) : Upgrade {
                 "NCRICIncludes" to "date.completeddatetime"
         )
 
-        val rangeClausesToOffsets = mapOf(
-                " AND $DATETIME_COL >= '2019-11-03 10:00:00.000000-00' " to 8, // PST
-                " AND $DATETIME_COL >= '2019-03-11 10:00:00.000000-00' AND $DATETIME_COL < '2019-11-03 10:00:00.000000-00' " to 7, // PDT
-                " AND $DATETIME_COL >= '2018-12-17 10:00:00.000000-00' AND $DATETIME_COL < '2019-03-11 10:00:00.000000-00' " to 8 // PST (and earlier data should be expired)
-        )
-
         val entitySetsByName = toolbox.entitySets.values.associateBy { it.name }
         val propertyTypesByFqn = toolbox.propertyTypes.values.associate { it.type.fullQualifiedNameAsString to it.id }
 
@@ -43,22 +37,14 @@ class AdjustNCRICDataDateTimes(private val toolbox: Toolbox) : Upgrade {
 
             logger.info("About to update values for entity set ${it.key}")
 
-            rangeClausesToOffsets.entries.stream().parallel().forEach { rangeEntry ->
+            toolbox.hds.connection.use { conn ->
+                conn.prepareStatement(UPDATE_SQL).use { ps ->
+                    ps.setObject(1, entitySet.id)
+                    ps.setObject(2, propertyTypeId)
+                    ps.setArray(3, PostgresArrays.createIntArray(conn, entitySet.partitions))
 
-                val rangeSql = getUpdateSql(rangeEntry.key, rangeEntry.value)
-                logger.info("Range SQL for entity set ${entitySet.name}: $rangeSql")
-
-                toolbox.hds.connection.use { conn ->
-                    conn.prepareStatement(rangeSql).use { ps ->
-                        ps.setObject(1, entitySet.id)
-                        ps.setObject(2, propertyTypeId)
-                        ps.setArray(3, PostgresArrays.createIntArray(conn, entitySet.partitions))
-
-                        ps.execute()
-                    }
+                    ps.execute()
                 }
-
-                logger.info("Updated range ${rangeEntry.key} for entity set ${entitySet.name}")
             }
 
             logger.info("Finished updating values for entity set ${it.key}")
@@ -67,12 +53,12 @@ class AdjustNCRICDataDateTimes(private val toolbox: Toolbox) : Upgrade {
         return true
     }
 
-    private fun getUpdateSql(rangeClause: String, offset: Int): String {
-        return "UPDATE ${DATA.name} SET $DATETIME_COL = ($DATETIME_COL at time zone 'UTC' + interval '$offset hours') at time zone 'UTC' " +
-                "WHERE ${ENTITY_SET_ID.name} = ? " +
-                "AND ${PROPERTY_TYPE_ID.name} = ? " +
-                "AND ${PARTITION.name} = ANY(?)" +
-                rangeClause
-    }
+    val UPDATE_SQL = "UPDATE ${DATA.name} " +
+            "SET $DATETIME_COL = $DATETIME_COL at time zone 'UTC' at time zone 'America/Los_Angeles' " +
+            "WHERE ${ENTITY_SET_ID.name} = ? " +
+            "AND ${PROPERTY_TYPE_ID.name} = ? " +
+            "AND ${PARTITION.name} = ANY(?) " +
+            "AND $DATETIME_COL > '2018-12-17 10:00:00.000000-00'" // we don't care about fixing data over a year old
+}
 
 }


### PR DESCRIPTION
Need to figure out what daylight-savings-related conversions have happened by this point given the prior conversion to GMT / whether we need to take that into account