### PR TITLE
LATTICE-2383 do cleanup with limiting the queries

### DIFF
--- a/src/main/kotlin/com/openlattice/mechanic/integrity/OrphanedLinkingPropertyData.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/integrity/OrphanedLinkingPropertyData.kt
@@ -22,11 +22,15 @@ package com.openlattice.mechanic.integrity
 
 import com.google.common.base.Stopwatch
 import com.openlattice.IdConstants
-import com.openlattice.data.DeleteType
 import com.openlattice.mechanic.Toolbox
+import com.openlattice.postgres.PostgresArrays
 import com.openlattice.postgres.PostgresColumn.*
 import com.openlattice.postgres.PostgresTable.DATA
+import com.openlattice.postgres.ResultSetAdapters
+import com.openlattice.postgres.streams.BasePostgresIterable
+import com.openlattice.postgres.streams.StatementHolderSupplier
 import org.slf4j.LoggerFactory
+import java.util.*
 import java.util.concurrent.TimeUnit
 
 class OrphanedLinkingPropertyData(private val toolbox: Toolbox) : Check {
@@ -41,29 +45,68 @@ class OrphanedLinkingPropertyData(private val toolbox: Toolbox) : Check {
     }
 
     private fun tombstoneOrphanedLinkingProperties() {
-        executeUpdate(tombStoneSql, DeleteType.Soft)
+        logger.info("Starting task to clear orphaned linking property types values.")
+        val sw = Stopwatch.createStarted()
+
+        do {
+            sw.reset().start()
+
+            val count = toolbox.hds.connection.use { conn ->
+                conn.createStatement().use {
+                    it.executeUpdate(tombStoneSql)
+                }
+            }
+
+            logger.info(
+                    "Cleared $count orphaned linking property types in ${DATA.name} table in " +
+                            "${sw.elapsed(TimeUnit.MILLISECONDS)} ms."
+            )
+        } while (count > 0)
     }
 
     private fun deleteOrphanedLinkingProperties() {
-        executeUpdate(deleteSql, DeleteType.Hard)
-    }
-
-    private fun executeUpdate(sql: String, deleteType: DeleteType) {
-        val deleteTypeStr1 = if (deleteType == DeleteType.Hard) "delete" else "clear"
-        val deleteTypeStr2 = if (deleteType == DeleteType.Hard) "Deleted" else "Cleared"
-
+        logger.info("Starting task to delete orphaned linking property types values.")
         val sw = Stopwatch.createStarted()
-        logger.info("Starting task to $deleteTypeStr1 orphaned linking property types values.")
-        val count = toolbox.hds.connection.use { conn ->
-            conn.createStatement().use {
-                it.executeUpdate(sql)
-            }
-        }
-        logger.info(
-                "$deleteTypeStr2 $count orphaned linking property types in ${DATA.name} table in " +
-                        "${sw.elapsed(TimeUnit.MILLISECONDS)} ms.")
 
+        do {
+            sw.reset().start()
+            var count = 0L
+
+            BasePostgresIterable<Triple<UUID, UUID, UUID>>(
+                    StatementHolderSupplier(toolbox.hds, selectDeletableSql, LIMIT)
+            ) { rs ->
+                Triple(ResultSetAdapters.id(rs), ResultSetAdapters.originId(rs), ResultSetAdapters.propertyTypeId(rs))
+            }
+                    .groupBy { it.first }
+                    .forEach { (linkingId, deletablesOfLinkingId) ->
+                        deletablesOfLinkingId
+                                .map { it.second to it.third }
+                                .groupBy { it.first }
+                                .forEach { (originId, propertyTypeIdsByOriginId) ->
+                                    count += toolbox.hds.connection.use { conn ->
+                                        val propertyTypeIdsArr = PostgresArrays.createUuidArray(
+                                                conn,
+                                                propertyTypeIdsByOriginId.map { it.second }
+                                        )
+                                        conn.prepareStatement(deleteSql).use {
+                                            it.setObject(1, linkingId)
+                                            it.setObject(2, originId)
+                                            it.setArray(3, propertyTypeIdsArr)
+                                            it.executeUpdate()
+                                        }
+                                    }
+                                }
+                    }
+
+            logger.info(
+                    "Deleted $count orphaned linking property types in ${DATA.name} table in " +
+                            "${sw.elapsed(TimeUnit.MILLISECONDS)} ms."
+            )
+        } while (count > 0)
     }
+
+
+    private val LIMIT = 3000
 
     // @formatter:off
     private val tombStoneSql =
@@ -74,7 +117,8 @@ class OrphanedLinkingPropertyData(private val toolbox: Toolbox) : Check {
                 "WHERE " +
                     "${VERSION.name} < 0 " +
                     "AND ${ORIGIN_ID.name} = '${IdConstants.EMPTY_ORIGIN_ID.id}' " +
-            ")" +
+                "LIMIT $LIMIT " +
+            ") " +
             "UPDATE ${DATA.name} as d " +
             "SET " +
                 "${VERSION.name} = actual_version, " +
@@ -85,11 +129,11 @@ class OrphanedLinkingPropertyData(private val toolbox: Toolbox) : Check {
                 "d.${ORIGIN_ID.name} = cleared_entities.${ID.name} " +
                 "AND d.${PROPERTY_TYPE_ID.name} = cleared_entities.${PROPERTY_TYPE_ID.name} " +
                 "AND d.${VERSION.name} > 0 " +
-                "AND d.${ORIGIN_ID.name} != '${IdConstants.EMPTY_ORIGIN_ID.id}'"
+                "AND d.${ORIGIN_ID.name} != '${IdConstants.EMPTY_ORIGIN_ID.id}' "
 
 
-    private val deleteSql =
-            "DELETE FROM ${DATA.name} " +
+    private val selectDeletableSql =
+            "SELECT ${ID.name}, ${ORIGIN_ID.name}, ${PROPERTY_TYPE_ID.name} FROM ${DATA.name} " +
             "WHERE " +
                 "( ${ORIGIN_ID.name}, ${PROPERTY_TYPE_ID.name} ) NOT IN " +
                     "( " +
@@ -98,6 +142,11 @@ class OrphanedLinkingPropertyData(private val toolbox: Toolbox) : Check {
                         "WHERE ${ORIGIN_ID.name} = '${IdConstants.EMPTY_ORIGIN_ID.id}' " +
                     ") " +
                 "AND ${VERSION.name} > 0 " +
-                "AND ${ORIGIN_ID.name} != '${IdConstants.EMPTY_ORIGIN_ID.id}' "
+                "AND ${ORIGIN_ID.name} != '${IdConstants.EMPTY_ORIGIN_ID.id}' " +
+            "LIMIT $LIMIT"
+
+    private val deleteSql =
+            "DELETE FROM ${DATA.name} " +
+            "WHERE ${ID.name} = ? AND ${ORIGIN_ID.name} = ? AND ${PROPERTY_TYPE_ID.name} = ANY( ? )"
     // @formatter:on
 }

--- a/src/main/kotlin/com/openlattice/mechanic/integrity/OrphanedLinkingPropertyData.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/integrity/OrphanedLinkingPropertyData.kt
@@ -84,13 +84,12 @@ class OrphanedLinkingPropertyData(private val toolbox: Toolbox) : Check {
                     .groupBy { it.linkingId }
                     .forEach { (linkingId, deletablesOfLinkingId) ->
                         deletablesOfLinkingId
-                                .map { it.originId to it.propertyTypeId }
-                                .groupBy { it.first } // originId
-                                .forEach { (originId, propertyTypeIdsByOriginId) ->
+                                .groupBy { it.originId }
+                                .forEach { (originId, deletablesOfOriginId) ->
                                     count += toolbox.hds.connection.use { conn ->
                                         val propertyTypeIdsArr = PostgresArrays.createUuidArray(
                                                 conn,
-                                                propertyTypeIdsByOriginId.map { it.second }
+                                                deletablesOfOriginId.map { it.propertyTypeId }
                                         )
                                         conn.prepareStatement(deleteSql).use {
                                             it.setObject(1, linkingId)

--- a/src/main/kotlin/com/openlattice/mechanic/integrity/OrphanedLinkingPropertyData.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/integrity/OrphanedLinkingPropertyData.kt
@@ -73,7 +73,7 @@ class OrphanedLinkingPropertyData(private val toolbox: Toolbox) : Check {
             var count = 0L
 
             BasePostgresIterable<Triple<UUID, UUID, UUID>>(
-                    StatementHolderSupplier(toolbox.hds, selectDeletableSql, LIMIT)
+                    StatementHolderSupplier(toolbox.hds, selectDeletableSql)
             ) { rs ->
                 Triple(ResultSetAdapters.id(rs), ResultSetAdapters.originId(rs), ResultSetAdapters.propertyTypeId(rs))
             }


### PR DESCRIPTION
This PR is to fix `The intermediate result size exceeds citus.max_intermediate_result_size (currently 1048576 kB)` citus error in the cleanup task.
For the clean query it was pretty straightforward, since I could limit the CTE itself, but for the delete query, bc it's a `NOT IN` predicate, I had to do a limited select first and then do the deletes grouped by id(linkingId) and originId for resulted property types.

Clear sql:
```
WITH cleared_entities AS
  (SELECT id, property_type_id, VERSION AS actual_version
   FROM DATA
   WHERE VERSION < 0
     AND origin_id = '7fffffff-ffff-ffff-7fff-ffffffffffff' LIMIT 3000)
UPDATE DATA AS d
SET VERSION = actual_version,
              versions = versions || ARRAY[actual_version],
                                          last_write = 'now()'
FROM cleared_entities
WHERE d.origin_id = cleared_entities.id
  AND d.property_type_id = cleared_entities.property_type_id
  AND d.VERSION > 0
  AND d.origin_id != '7fffffff-ffff-ffff-7fff-ffffffffffff'
```

Select for delete sql:
```
SELECT id, origin_id, property_type_id
FROM DATA
WHERE (origin_id, property_type_id) NOT IN
    (SELECT id, property_type_id
     FROM DATA
     WHERE origin_id = '7fffffff-ffff-ffff-7fff-ffffffffffff')
  AND VERSION > 0
  AND origin_id != '7fffffff-ffff-ffff-7fff-ffffffffffff' LIMIT 3000
```

Delete sql:
```
DELETE FROM data WHERE id = ? AND origin_id = ? AND property_type_id = ANY( ? )
```