### PR TITLE
Bugfix/lattice 2383 batch orphaned linking data cleanup

### DIFF
--- a/src/main/kotlin/com/openlattice/mechanic/Mechanic.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/Mechanic.kt
@@ -26,10 +26,8 @@ import com.google.common.collect.Maps
 import com.kryptnostic.rhizome.configuration.ConfigurationConstants.Profiles.AWS_CONFIGURATION_PROFILE
 import com.kryptnostic.rhizome.configuration.ConfigurationConstants.Profiles.LOCAL_CONFIGURATION_PROFILE
 import com.kryptnostic.rhizome.core.Rhizome
-import com.kryptnostic.rhizome.pods.AsyncPod
-import com.kryptnostic.rhizome.pods.ConfigurationPod
-import com.kryptnostic.rhizome.pods.HazelcastPod
-import com.kryptnostic.rhizome.pods.hazelcast.RegistryBasedHazelcastInstanceConfigurationPod
+import com.kryptnostic.rhizome.core.RhizomeApplicationServer
+import com.kryptnostic.rhizome.hazelcast.serializers.RhizomeUtils
 import com.kryptnostic.rhizome.startup.Requirement
 import com.openlattice.assembler.pods.AssemblerConfigurationPod
 import com.openlattice.auth0.Auth0Pod
@@ -124,12 +122,13 @@ fun main(args: Array<String>) {
  */
 class Mechanic {
 
-    private val mechanicPods = arrayOf(
-            AssemblerConfigurationPod::class.java, AsyncPod::class.java, Auth0Pod::class.java,
-            ConfigurationPod::class.java, HazelcastPod::class.java, JdbcPod::class.java, MapstoresPod::class.java,
-            MechanicIntegrityPod::class.java, MechanicRetireePod::class.java, MechanicUpgradePod::class.java,
-            PostgresPod::class.java, RegistryBasedHazelcastInstanceConfigurationPod::class.java,
-            SharedStreamSerializersPod::class.java
+    private val mechanicPods = RhizomeUtils.Pods.concatenate(
+            RhizomeApplicationServer.DEFAULT_PODS,
+            arrayOf(
+                    AssemblerConfigurationPod::class.java, Auth0Pod::class.java, JdbcPod::class.java,
+                    MapstoresPod::class.java, MechanicIntegrityPod::class.java, MechanicRetireePod::class.java,
+                    MechanicUpgradePod::class.java, PostgresPod::class.java, SharedStreamSerializersPod::class.java
+            )
     )
 
     private val context = AnnotationConfigApplicationContext()

--- a/src/main/kotlin/com/openlattice/mechanic/integrity/OrphanedLinkingPropertyData.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/integrity/OrphanedLinkingPropertyData.kt
@@ -75,13 +75,14 @@ class OrphanedLinkingPropertyData(private val toolbox: Toolbox) : Check {
         var countTotal = 0L
 
         selectAllLinkingIds()
+                .groupBy { it.partition }
                 .asSequence()
                 .chunked(fetchDelete)
-                .forEachIndexed { batchNum, idsBatch ->
+                .forEachIndexed { batchNum, idsBatchByPartition ->
                     sw.reset().start()
                     var count = 0L
 
-                    idsBatch.groupBy { it.partition }.forEach {
+                    idsBatchByPartition.forEach {
 
                         val linkingIds = it.value.map { it.linkingId }.toSet()
                         val originIds = it.value.map { it.originId }.toSet()

--- a/src/main/kotlin/com/openlattice/mechanic/integrity/OrphanedLinkingPropertyData.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/integrity/OrphanedLinkingPropertyData.kt
@@ -109,7 +109,8 @@ class OrphanedLinkingPropertyData(private val toolbox: Toolbox) : Check {
     }
 
 
-    private val LIMIT = 3000
+    private val limitClear = 3000
+    private val limitDelete = 100
 
     // @formatter:off
     private val tombStoneSql =
@@ -120,7 +121,7 @@ class OrphanedLinkingPropertyData(private val toolbox: Toolbox) : Check {
                 "WHERE " +
                     "${VERSION.name} < 0 " +
                     "AND ${ORIGIN_ID.name} = '${IdConstants.EMPTY_ORIGIN_ID.id}' " +
-                "LIMIT $LIMIT " +
+                "LIMIT $limitClear " +
             ") " +
             "UPDATE ${DATA.name} as d " +
             "SET " +
@@ -146,7 +147,7 @@ class OrphanedLinkingPropertyData(private val toolbox: Toolbox) : Check {
                     ") " +
                 "AND ${VERSION.name} > 0 " +
                 "AND ${ORIGIN_ID.name} != '${IdConstants.EMPTY_ORIGIN_ID.id}' " +
-            "LIMIT $LIMIT"
+            "LIMIT $limitDelete"
 
     private val deleteSql =
             "DELETE FROM ${DATA.name} " +


### PR DESCRIPTION
Changed the delete logic to first select a batch of linking ids and their origin ids and then check, if any of the properties of those origin id are deleted, while the linking entity properties are there and if not, delete those rows.

Select linking ids and their origin ids (with 3000 fetch size):
```
SELECT id,
       origin_id,
       entity_set_id,
       partition
FROM DATA
WHERE origin_id != '7fffffff-ffff-ffff-7fff-ffffffffffff'
  AND VERSION > 0;
```

Select deletable properties from ^ that batch:
```
SELECT id,
       origin_id,
       property_type_id
FROM DATA
WHERE (origin_id,
       property_type_id) NOT IN
    (SELECT id,
            property_type_id
     FROM DATA
     WHERE origin_id = '7fffffff-ffff-ffff-7fff-ffffffffffff'
       AND id = ANY(?)
       AND entity_set_id = ANY(?)
       AND VERSION > 0)
  AND id = ANY(?)
  AND origin_id = ANY(?)
  AND entity_set_id = ANY(?)
  AND partition = ?
  AND VERSION > 0
  AND origin_id != '7fffffff-ffff-ffff-7fff-ffffffffffff';
```

Delete orphaned properties that matched ^ that query:
```
DELETE
FROM DATA
WHERE id = ?
  AND origin_id = ?
  AND partition = ?
  AND property_type_id = ANY(?);
```