### PR TITLE
LATTICE-61 configuration service should load from aws

### DIFF
--- a/src/main/kotlin/com/openlattice/mechanic/Toolbox.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/Toolbox.kt
@@ -24,6 +24,7 @@ package com.openlattice.mechanic
 import com.google.common.base.Stopwatch
 import com.google.common.util.concurrent.ListeningExecutorService
 import com.hazelcast.core.HazelcastInstance
+import com.kryptnostic.rhizome.pods.ConfigurationLoader
 import com.openlattice.postgres.CitusDistributedTableDefinition
 import com.openlattice.postgres.PostgresTableDefinition
 import com.openlattice.postgres.PostgresTableManager
@@ -47,7 +48,8 @@ class Toolbox(
         etms: EntityTypeMapstore,
         internal val esms: EntitySetMapstore,
         val executor: ListeningExecutorService,
-        val hazelcast: HazelcastInstance
+        val hazelcast: HazelcastInstance,
+        val configurationLoader: ConfigurationLoader
 ) {
     companion object {
         private val logger = LoggerFactory.getLogger(Toolbox::class.java)

--- a/src/main/kotlin/com/openlattice/mechanic/pods/MechanicToolboxPod.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/pods/MechanicToolboxPod.kt
@@ -2,6 +2,7 @@ package com.openlattice.mechanic.pods
 
 import com.google.common.util.concurrent.ListeningExecutorService
 import com.hazelcast.core.HazelcastInstance
+import com.kryptnostic.rhizome.pods.ConfigurationLoader
 import com.openlattice.hazelcast.pods.MapstoresPod
 import com.openlattice.mechanic.Toolbox
 import com.openlattice.postgres.PostgresTableManager
@@ -35,6 +36,9 @@ class MechanicToolboxPod {
     @Inject
     private lateinit var hazelcastInstance: HazelcastInstance
 
+    @Inject
+    private lateinit var configurationLoader: ConfigurationLoader
+
 
     @Bean
     fun toolbox(): Toolbox {
@@ -45,7 +49,8 @@ class MechanicToolboxPod {
                 mapstoresPod.entityTypeMapstore() as EntityTypeMapstore,
                 mapstoresPod.entitySetMapstore() as EntitySetMapstore,
                 executor,
-                hazelcastInstance
+                hazelcastInstance,
+                configurationLoader
         )
     }
 }

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/MediaServerCleanup.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/MediaServerCleanup.kt
@@ -21,13 +21,6 @@
 
 package com.openlattice.mechanic.upgrades
 
-import com.amazonaws.regions.Region
-import com.amazonaws.regions.Regions
-import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
-import com.kryptnostic.rhizome.configuration.amazon.AmazonLaunchConfiguration
-import com.kryptnostic.rhizome.configuration.amazon.AwsLaunchConfiguration
-import com.openlattice.ResourceConfigurationLoader
 import com.openlattice.data.storage.ByteBlobDataManager
 import com.openlattice.data.storage.aws.AwsBlobDataService
 import com.openlattice.datastore.configuration.DatastoreConfiguration
@@ -74,15 +67,7 @@ class MediaServerCleanup(private val toolbox: Toolbox) : Upgrade {
                              }).toMap()
 
     init {
-        val awsConfig = ResourceConfigurationLoader
-                .loadConfigurationFromResource("aws.yaml", AwsLaunchConfiguration::class.java)
-        val s3 = newS3Client(awsConfig)
-        val config = ResourceConfigurationLoader.loadConfigurationFromS3(
-                s3,
-                awsConfig.bucket,
-                awsConfig.folder,
-                DatastoreConfiguration::class.java
-        )
+        val config = toolbox.configurationLoader.load(DatastoreConfiguration::class.java)
         val byteBlobDataManager = AwsBlobDataService(config, toolbox.executor)
         this.byteBlobDataManager = byteBlobDataManager
     }
@@ -124,12 +109,6 @@ class MediaServerCleanup(private val toolbox: Toolbox) : Upgrade {
             }
         }
 
-    }
-
-    private fun newS3Client(awsConfig: AmazonLaunchConfiguration): AmazonS3 {
-        val builder = AmazonS3ClientBuilder.standard()
-        builder.region = Region.getRegion(awsConfig.region.orElse(Regions.DEFAULT_REGION)).name
-        return builder.build()
     }
 
     private fun addMockS3Table() {

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/MediaServerUpgrade.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/MediaServerUpgrade.kt
@@ -5,8 +5,6 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.kryptnostic.rhizome.configuration.amazon.AmazonLaunchConfiguration
-import com.kryptnostic.rhizome.configuration.amazon.AwsLaunchConfiguration
-import com.openlattice.ResourceConfigurationLoader
 import com.openlattice.data.storage.ByteBlobDataManager
 import com.openlattice.data.storage.aws.AwsBlobDataService
 import com.openlattice.data.util.PostgresDataHasher
@@ -45,15 +43,7 @@ class MediaServerUpgrade(private val toolbox: Toolbox) : Upgrade {
     }
 
     private fun setUp() {
-        val awsConfig = ResourceConfigurationLoader
-                .loadConfigurationFromResource("aws.yaml", AwsLaunchConfiguration::class.java)
-        val s3 = newS3Client(awsConfig)
-        val config = ResourceConfigurationLoader.loadConfigurationFromS3(
-                s3,
-                awsConfig.bucket,
-                awsConfig.folder,
-                DatastoreConfiguration::class.java
-        )
+        val config = toolbox.configurationLoader.load(DatastoreConfiguration::class.java)
         val byteBlobDataManager = AwsBlobDataService(config, toolbox.executor)
         this.byteBlobDataManager = byteBlobDataManager
     }


### PR DESCRIPTION
Put configuration loader behind an interface that abstracts away
different config sources.

Also adds a configuration profile for running in a container and
loading from a fixed volume path, rather than from classpath.