### PR TITLE
add findbugs now that conductor-client doesnt transitive it in

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,12 @@ dependencies {
     compile "org.ow2.asm:asm:$asm_version"
     compile "commons-cli:commons-cli:$commons_cli_version"
 
+    compileOnly "net.jcip:jcip-annotations:${jcip_version}"
+    compileOnly "com.github.spotbugs:spotbugs-annotations:${spotbugs_annotations_version}"
+    testCompileOnly "net.jcip:jcip-annotations:${jcip_version}"
+    testCompileOnly "com.github.spotbugs:spotbugs-annotations:${spotbugs_annotations_version}"
+
+    compileOnly "com.google.code.findbugs:findbugs:${findbugs_version}"
     if (project.hasProperty('developmentMode') && project.developmentMode) {
         logger.quiet(project.name + " using project dependencies.")
         compile project(":rhizome")

--- a/src/main/kotlin/com/openlattice/mechanic/integrity/IntegrityChecks.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/integrity/IntegrityChecks.kt
@@ -47,15 +47,13 @@ private val logger = LoggerFactory.getLogger(IntegrityChecks::class.java)
 class IntegrityChecks(private val toolbox: Toolbox) : Check {
     override fun check(): Boolean {
         logger.info("Integrity checks aren't fully implemented.")
-        val corruptEntitySets = toolbox.entitySets.filter {
+        toolbox.entitySets.filter {
             logger.info("Checking entity set {}", it.value.name)
             !hasIdIntegrity(it.key)
         }.toMap()
 
         return true
     }
-
-
 
     fun ensureEntityKeyIdsSynchronized() {
         val latches: MutableList<CountDownLatch> = mutableListOf()

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/ConvertAppsToEntityTypeCollections.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/ConvertAppsToEntityTypeCollections.kt
@@ -4,9 +4,6 @@ import com.google.common.collect.ImmutableSet
 import com.google.common.eventbus.EventBus
 import com.hazelcast.query.Predicates
 import com.openlattice.apps.App
-import com.openlattice.apps.AppConfigKey
-import com.openlattice.apps.AppType
-import com.openlattice.apps.AppTypeSetting
 import com.openlattice.authorization.*
 import com.openlattice.authorization.securable.SecurableObjectType
 import com.openlattice.collections.CollectionTemplateKey
@@ -17,7 +14,6 @@ import com.openlattice.edm.events.EntitySetCollectionCreatedEvent
 import com.openlattice.edm.events.EntityTypeCollectionCreatedEvent
 import com.openlattice.hazelcast.HazelcastMap
 import com.openlattice.mechanic.Toolbox
-import com.openlattice.organizations.Organization
 import com.openlattice.postgres.mapstores.AppConfigMapstore
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import org.apache.olingo.commons.api.edm.FullQualifiedName


### PR DESCRIPTION
This PR:
- stops using libraries pulled in transitively by c-c which are now absent