### PR TITLE
update historical migrations to not use named constants

### DIFF
--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/UpgradeEdgesTable.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/UpgradeEdgesTable.kt
@@ -309,8 +309,8 @@ class UpgradeEdgesTable(val toolbox: Toolbox) : Upgrade {
 
     fun migratedVersionSql(joinColumn: PostgresColumnDefinition, entitySetId: UUID, nonAuditEdgeEntitySetIds: Set<UUID>): String {
         val edgeEntitySetFilter = if (joinColumn == EDGE_ENTITY_SET_ID) " " else " AND ${EDGE_ENTITY_SET_ID.name} = ANY('{${nonAuditEdgeEntitySetIds.joinToString(",")}}') "
-        return "WITH for_migration AS ( UPDATE ${EDGES.name} SET migrated_version = abs(version) " +
-                "WHERE (id,edge_comp_1,edge_comp_2,${COMPONENT_TYPES.name}) in ( select id,edge_comp_1,edge_comp_2,${COMPONENT_TYPES.name} FROM ${EDGES.name} " +
+        return "WITH for_migration AS ( UPDATE edges SET migrated_version = abs(version) " +
+                "WHERE (id,edge_comp_1,edge_comp_2,${COMPONENT_TYPES.name}) in ( select id,edge_comp_1,edge_comp_2,${COMPONENT_TYPES.name} FROM edges " +
                 "WHERE ${COMPONENT_TYPES.name} = ${IdType.SRC.ordinal} AND ${joinColumn.name} = '$entitySetId' " +
                 "$edgeEntitySetFilter AND (migrated_version < abs(version)) " +
                 "LIMIT $BATCH_SIZE) RETURNING *) "
@@ -324,8 +324,8 @@ class UpgradeEdgesTable(val toolbox: Toolbox) : Upgrade {
             conn.createStatement().use {
                 it.execute(
                         "DO $$ BEGIN " +
-                                "IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = '${EDGES.name}' AND column_name = 'migrated_version') " +
-                                "THEN ALTER TABLE ${EDGES.name} ADD COLUMN migrated_version bigint NOT NULL DEFAULT 0 ; else raise NOTICE 'Column migrated_version already exists'; " +
+                                "IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = 'edges' AND column_name = 'migrated_version') " +
+                                "THEN ALTER TABLE edges ADD COLUMN migrated_version bigint NOT NULL DEFAULT 0 ; else raise NOTICE 'Column migrated_version already exists'; " +
                                 "END IF; END $$"
                 )
             }

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/UpgradeEntityKeyIdsTable.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/UpgradeEntityKeyIdsTable.kt
@@ -394,8 +394,8 @@ class UpgradeEntityKeyIdsTable(val toolbox: Toolbox) : Upgrade {
             conn.createStatement().use {
                 it.execute(
                         "DO $$ BEGIN " +
-                                "IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = '${ENTITY_KEY_IDS.name}' AND column_name = '$MIGRATED_VERSION') " +
-                                "THEN ALTER TABLE ${ENTITY_KEY_IDS.name} ADD COLUMN if not exists $MIGRATED_VERSION bigint NOT NULL DEFAULT 0 ; else raise NOTICE 'Column $MIGRATED_VERSION already exists'; " +
+                                "IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = 'entity_key_ids' AND column_name = '$MIGRATED_VERSION') " +
+                                "THEN ALTER TABLE entity_key_ids ADD COLUMN if not exists $MIGRATED_VERSION bigint NOT NULL DEFAULT 0 ; else raise NOTICE 'Column $MIGRATED_VERSION already exists'; " +
                                 "END IF; END $$"
                 )
             }

--- a/src/main/kotlin/com/openlattice/mechanic/upgrades/UpgradeEntitySetPartitions.kt
+++ b/src/main/kotlin/com/openlattice/mechanic/upgrades/UpgradeEntitySetPartitions.kt
@@ -4,7 +4,6 @@ package com.openlattice.mechanic.upgrades
 import com.openlattice.edm.set.EntitySetFlag
 import com.openlattice.mechanic.Toolbox
 import com.openlattice.postgres.PostgresColumn.*
-import com.openlattice.postgres.PostgresTable.ENTITY_KEY_IDS
 import com.openlattice.postgres.PostgresTable.ENTITY_SETS
 import com.openlattice.postgres.ResultSetAdapters
 import com.openlattice.postgres.streams.BasePostgresIterable
@@ -332,7 +331,7 @@ class UpgradeEntitySetPartitions(private val toolbox: Toolbox) : Upgrade {
 
 private data class EntitySetInfo(val count: Long, val flags: Set<EntitySetFlag>)
 
-private val SELECT_ENTITY_SET_COUNTS = "(SELECT ${ENTITY_SET_ID.name}, count(*) FROM ${ENTITY_KEY_IDS.name} GROUP BY ${ENTITY_SET_ID.name}) as entity_set_counts"
+private val SELECT_ENTITY_SET_COUNTS = "(SELECT ${ENTITY_SET_ID.name}, count(*) FROM entity_key_ids GROUP BY ${ENTITY_SET_ID.name}) as entity_set_counts"
 private val SELECT_ENTITY_SET_FLAGS = "(select id as ${ENTITY_SET_ID.name}, ${FLAGS.name} from ${ENTITY_SETS.name} WHERE ${PARTITIONS.name} = '{}') as entity_set_flags"
 
 private val GET_ENTITY_SET_COUNT = "SELECT ${ENTITY_SET_ID.name}, ${FLAGS.name}, CASE WHEN count IS NULL THEN 1 ELSE count END " +


### PR DESCRIPTION
This PR:
- Removes long unused edges and entity_key_ids table objects